### PR TITLE
Fixed WiFi.hostname

### DIFF
--- a/VFR_Sectional-github.ino
+++ b/VFR_Sectional-github.ino
@@ -87,7 +87,7 @@ void loop() {
     if (ledStatus) fill_solid(leds, NUM_AIRPORTS, CRGB::Orange); // indicate status with LEDs, but only on first run or error
     FastLED.show();
     WiFi.mode(WIFI_STA);
-    WiFi.hostname("LED Sectional " + WiFi.macAddress());
+    WiFi.hostname("LED-Sectional-" + WiFi.macAddress());
     //wifi_set_sleep_type(LIGHT_SLEEP_T); // use light sleep mode for all delays
     Serial.print("WiFi connecting..");
     WiFi.begin(ssid, pass);


### PR DESCRIPTION
WiFi host name will not work with spaces, from what I've found. Replaced spaces with "-"